### PR TITLE
feat(azerothcore): add worldserver, authserver, and db-import images

### DIFF
--- a/apps/azerothcore-authserver/Dockerfile
+++ b/apps/azerothcore-authserver/Dockerfile
@@ -1,0 +1,1 @@
+FROM acore/ac-wotlk-authserver:master

--- a/apps/azerothcore-authserver/ci/latest.sh
+++ b/apps/azerothcore-authserver/ci/latest.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 version="$(curl -sX GET "https://api.github.com/repos/azerothcore/azerothcore-wotlk/commits?per_page=1&sha=master" 2>/dev/null \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['commit']['committer']['date'][:10])")"
+  | jq -r '.[0].commit.committer.date[:10]')"
 printf "%s" "${version}"

--- a/apps/azerothcore-authserver/ci/latest.sh
+++ b/apps/azerothcore-authserver/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version="$(curl -sX GET "https://api.github.com/repos/azerothcore/azerothcore-wotlk/commits?per_page=1&sha=master" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['commit']['committer']['date'][:10])")"
+printf "%s" "${version}"

--- a/apps/azerothcore-authserver/metadata.json
+++ b/apps/azerothcore-authserver/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "azerothcore-authserver",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "AzerothCore WotLK authserver",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "cli"
+      }
+    }
+  ]
+}

--- a/apps/azerothcore-db-import/Dockerfile
+++ b/apps/azerothcore-db-import/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine/git AS module-cloner
+RUN git clone --depth 1 https://github.com/azerothcore/mod-solocraft /modules/mod-solocraft \
+ && git clone --depth 1 https://github.com/azerothcore/mod-ah-bot /modules/mod-ah-bot \
+ && git clone --depth 1 https://github.com/ZhengPeiRu21/mod-individual-progression /modules/mod-individual-progression
+
+FROM acore/ac-wotlk-db-import:master
+COPY --from=module-cloner /modules/mod-solocraft /azerothcore/modules/mod-solocraft
+COPY --from=module-cloner /modules/mod-ah-bot /azerothcore/modules/mod-ah-bot
+COPY --from=module-cloner /modules/mod-individual-progression /azerothcore/modules/mod-individual-progression

--- a/apps/azerothcore-db-import/ci/latest.sh
+++ b/apps/azerothcore-db-import/ci/latest.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 version="$(curl -sX GET "https://api.github.com/repos/azerothcore/azerothcore-wotlk/commits?per_page=1&sha=master" 2>/dev/null \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['commit']['committer']['date'][:10])")"
+  | jq -r '.[0].commit.committer.date[:10]')"
 printf "%s" "${version}"

--- a/apps/azerothcore-db-import/ci/latest.sh
+++ b/apps/azerothcore-db-import/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version="$(curl -sX GET "https://api.github.com/repos/azerothcore/azerothcore-wotlk/commits?per_page=1&sha=master" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['commit']['committer']['date'][:10])")"
+printf "%s" "${version}"

--- a/apps/azerothcore-db-import/metadata.json
+++ b/apps/azerothcore-db-import/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "azerothcore-db-import",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "AzerothCore WotLK database importer with mod-solocraft, mod-ah-bot, and mod-individual-progression SQL",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "cli"
+      }
+    }
+  ]
+}

--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -1,0 +1,23 @@
+FROM acore/ac-wotlk-dev:master AS builder
+
+WORKDIR /azerothcore-src
+
+RUN git clone --depth 1 https://github.com/azerothcore/azerothcore-wotlk . \
+ && git clone --depth 1 https://github.com/azerothcore/mod-solocraft modules/mod-solocraft \
+ && git clone --depth 1 https://github.com/azerothcore/mod-ah-bot modules/mod-ah-bot \
+ && git clone --depth 1 https://github.com/ZhengPeiRu21/mod-individual-progression modules/mod-individual-progression
+
+RUN cmake -B cmake-build \
+      -DCMAKE_INSTALL_PREFIX=/azerothcore/env/dist \
+      -DAPPS_BUILD=worldserver \
+      -DTOOLS_BUILD=none \
+      -DSCRIPTS=static \
+      -DMODULES=static \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_C_COMPILER=clang \
+ && cmake --build cmake-build --target install -j$(nproc)
+
+FROM acore/ac-wotlk-worldserver:master
+COPY --from=builder /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
+COPY --from=builder /azerothcore/env/dist/etc/modules/ /azerothcore/env/ref/etc/modules/

--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone --depth 1 https://github.com/azerothcore/azerothcore-wotlk . \
 
 RUN cmake -B cmake-build \
       -DCMAKE_INSTALL_PREFIX=/azerothcore/env/dist \
-      -DAPPS_BUILD=worldserver \
+      -DAPPS_BUILD=world-only \
       -DTOOLS_BUILD=none \
       -DSCRIPTS=static \
       -DMODULES=static \

--- a/apps/azerothcore-worldserver/ci/latest.sh
+++ b/apps/azerothcore-worldserver/ci/latest.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 version="$(curl -sX GET "https://api.github.com/repos/azerothcore/azerothcore-wotlk/commits?per_page=1&sha=master" 2>/dev/null \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['commit']['committer']['date'][:10])")"
+  | jq -r '.[0].commit.committer.date[:10]')"
 printf "%s" "${version}"

--- a/apps/azerothcore-worldserver/ci/latest.sh
+++ b/apps/azerothcore-worldserver/ci/latest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+version="$(curl -sX GET "https://api.github.com/repos/azerothcore/azerothcore-wotlk/commits?per_page=1&sha=master" 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['commit']['committer']['date'][:10])")"
+printf "%s" "${version}"

--- a/apps/azerothcore-worldserver/metadata.json
+++ b/apps/azerothcore-worldserver/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "azerothcore-worldserver",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "AzerothCore WotLK worldserver with mod-solocraft, mod-ah-bot, and mod-individual-progression",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": false,
+        "type": "cli"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Three new images for a WoW WotLK 3.3.5a (AzerothCore) single-player server:

- azerothcore-worldserver: multi-stage build compiling mod-solocraft, mod-ah-bot, and mod-individual-progression as static modules into the worldserver binary; runtime base is acore/ac-wotlk-worldserver:master
- azerothcore-authserver: thin wrapper around acore/ac-wotlk-authserver:master
- azerothcore-db-import: extends acore/ac-wotlk-db-import:master with all three module directories cloned into /azerothcore/modules/ so the dbimport binary picks up their SQL migrations