### PR TITLE
fix(azerothcore-worldserver): copy boost libs from builder stage

### DIFF
--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -21,3 +21,5 @@ RUN cmake -B cmake-build \
 FROM acore/ac-wotlk-worldserver:master
 COPY --from=builder /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
 COPY --from=builder /azerothcore/env/dist/etc/modules/ /azerothcore/env/ref/etc/modules/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libboost_*.so.1.83.0 /usr/lib/x86_64-linux-gnu/
+RUN ldconfig


### PR DESCRIPTION
acore/ac-wotlk-dev and acore/ac-wotlk-worldserver can diverge on boost versions when pulled independently. Copy the versioned .so files from the builder and refresh ldconfig so the binary resolves libboost_filesystem.so.1.83.0 at runtime.