### PR TITLE
fix(azerothcore-worldserver): remove ldconfig, base image runs non-root

### DIFF
--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -22,4 +22,3 @@ FROM acore/ac-wotlk-worldserver:master
 COPY --from=builder /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
 COPY --from=builder /azerothcore/env/dist/etc/modules/ /azerothcore/env/ref/etc/modules/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libboost_*.so.1.83.0 /usr/lib/x86_64-linux-gnu/
-RUN ldconfig


### PR DESCRIPTION
/usr/lib/x86_64-linux-gnu/ is a default dynamic linker search path so ldconfig is not needed; running it fails with permission denied.