### PR TITLE
fix(azerothcore-worldserver): build in worldserver image to fix GLIBC mismatch

### DIFF
--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -2,9 +2,11 @@ FROM acore/ac-wotlk-worldserver:master AS builder
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential cmake clang git \
-    libboost-all-dev libssl-dev default-libmysqlclient-dev \
-    libbz2-dev zlib1g-dev \
+    build-essential libtool cmake-data cmake clang \
+    git curl unzip openssl \
+    default-mysql-client default-libmysqlclient-dev libmysql++-dev \
+    libboost-all-dev libssl-dev \
+    libreadline-dev zlib1g-dev libbz2-dev libncurses5-dev \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /azerothcore-src

--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -2,7 +2,7 @@ FROM acore/ac-wotlk-worldserver:master AS builder
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake clang git \
+    build-essential cmake clang git \
     libboost-all-dev libssl-dev default-libmysqlclient-dev \
     libbz2-dev zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -23,6 +23,7 @@ RUN cmake -B cmake-build \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_CXX_COMPILER=clang++ \
       -DCMAKE_C_COMPILER=clang \
+      -DBoost_USE_STATIC_LIBS=ON \
  && cmake --build cmake-build --target install -j$(nproc)
 
 FROM acore/ac-wotlk-worldserver:master

--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -1,4 +1,11 @@
-FROM acore/ac-wotlk-dev:master AS builder
+FROM acore/ac-wotlk-worldserver:master AS builder
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake clang git \
+    libboost-all-dev libssl-dev default-libmysqlclient-dev \
+    libbz2-dev zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /azerothcore-src
 
@@ -21,4 +28,3 @@ RUN cmake -B cmake-build \
 FROM acore/ac-wotlk-worldserver:master
 COPY --from=builder /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
 COPY --from=builder /azerothcore/env/dist/etc/modules/ /azerothcore/env/ref/etc/modules/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libboost_*.so.1.83.0 /usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
acore/ac-wotlk-dev:master (Ubuntu 24.04, GLIBC 2.38) and acore/ac-wotlk-worldserver:master (Ubuntu 22.04, GLIBC 2.35) are out of sync. Installing build tools in the worldserver image as the builder stage ensures the compiled binary is compatible with the runtime GLIBC.