### PR TITLE
fix(azerothcore-worldserver): copy SQL update files for DB auto-updater

### DIFF
--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -33,3 +33,7 @@ RUN for f in /azerothcore/env/dist/etc/modules/*.conf.dist; do cp "$f" "${f%.dis
 FROM acore/ac-wotlk-worldserver:master
 COPY --from=builder /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
 COPY --from=builder /azerothcore/env/dist/etc/modules/ /azerothcore/env/ref/etc/modules/
+COPY --from=builder /azerothcore-src/data/sql/updates/ /azerothcore-src/data/sql/updates/
+COPY --from=builder /azerothcore-src/modules/mod-solocraft/data/ /azerothcore-src/modules/mod-solocraft/data/
+COPY --from=builder /azerothcore-src/modules/mod-ah-bot/data/ /azerothcore-src/modules/mod-ah-bot/data/
+COPY --from=builder /azerothcore-src/modules/mod-individual-progression/data/ /azerothcore-src/modules/mod-individual-progression/data/


### PR DESCRIPTION
AC_UPDATES_ENABLE_DATABASES=1 requires SQL migration files at the default source path (/azerothcore-src). Copy core updates and module data directories from the builder so the worldserver can apply any pending schema migrations on startup.