### PR TITLE
fix(azerothcore): apply module SQL in db-import; remove SQL from worldserver

### DIFF
--- a/apps/azerothcore-db-import/Dockerfile
+++ b/apps/azerothcore-db-import/Dockerfile
@@ -7,6 +7,6 @@ FROM acore/ac-wotlk-db-import:master
 COPY --from=module-cloner /modules/mod-solocraft /azerothcore/modules/mod-solocraft
 COPY --from=module-cloner /modules/mod-ah-bot /azerothcore/modules/mod-ah-bot
 COPY --from=module-cloner /modules/mod-individual-progression /azerothcore/modules/mod-individual-progression
-COPY import-with-modules.sh /import-with-modules.sh
+COPY apps/azerothcore-db-import/import-with-modules.sh /import-with-modules.sh
 RUN chmod +x /import-with-modules.sh
 CMD ["/import-with-modules.sh"]

--- a/apps/azerothcore-db-import/Dockerfile
+++ b/apps/azerothcore-db-import/Dockerfile
@@ -7,3 +7,6 @@ FROM acore/ac-wotlk-db-import:master
 COPY --from=module-cloner /modules/mod-solocraft /azerothcore/modules/mod-solocraft
 COPY --from=module-cloner /modules/mod-ah-bot /azerothcore/modules/mod-ah-bot
 COPY --from=module-cloner /modules/mod-individual-progression /azerothcore/modules/mod-individual-progression
+COPY import-with-modules.sh /import-with-modules.sh
+RUN chmod +x /import-with-modules.sh
+CMD ["/import-with-modules.sh"]

--- a/apps/azerothcore-db-import/Dockerfile
+++ b/apps/azerothcore-db-import/Dockerfile
@@ -7,6 +7,5 @@ FROM acore/ac-wotlk-db-import:master
 COPY --from=module-cloner /modules/mod-solocraft /azerothcore/modules/mod-solocraft
 COPY --from=module-cloner /modules/mod-ah-bot /azerothcore/modules/mod-ah-bot
 COPY --from=module-cloner /modules/mod-individual-progression /azerothcore/modules/mod-individual-progression
-COPY apps/azerothcore-db-import/import-with-modules.sh /import-with-modules.sh
-RUN chmod +x /import-with-modules.sh
+COPY --chmod=755 apps/azerothcore-db-import/import-with-modules.sh /import-with-modules.sh
 CMD ["/import-with-modules.sh"]

--- a/apps/azerothcore-db-import/import-with-modules.sh
+++ b/apps/azerothcore-db-import/import-with-modules.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "==> Running AzerothCore database import..."
+/azerothcore/env/dist/bin/dbimport
+
+echo "==> Applying module SQL files..."
+
+apply_sql_dir() {
+  local dir="$1" host="$2" port="$3" user="$4" pass="$5" db="$6"
+  [ -d "$dir" ] || return 0
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    echo "  >> $(basename "$f")"
+    mysql -h"$host" -P"$port" -u"$user" -p"$pass" --force "$db" < "$f" 2>&1 \
+      | grep -Ev "^$|mysql: \[Warning\]" || true
+  done < <(find "$dir" -name "*.sql" -type f | sort)
+}
+
+IFS=';' read -r whost wport wuser wpass wdb <<< "${AC_WORLD_DATABASE_INFO}"
+IFS=';' read -r ahost aport auser apass adb <<< "${AC_LOGIN_DATABASE_INFO}"
+IFS=';' read -r chost cport cuser cpass cdb <<< "${AC_CHARACTER_DATABASE_INFO}"
+
+# mod-ah-bot
+apply_sql_dir "/azerothcore/modules/mod-ah-bot/data/sql/db-world/" \
+  "$whost" "$wport" "$wuser" "$wpass" "$wdb"
+
+# mod-solocraft
+apply_sql_dir "/azerothcore/modules/mod-solocraft/data/sql/db-world/" \
+  "$whost" "$wport" "$wuser" "$wpass" "$wdb"
+apply_sql_dir "/azerothcore/modules/mod-solocraft/data/sql/db-characters/" \
+  "$chost" "$cport" "$cuser" "$cpass" "$cdb"
+
+# mod-individual-progression (base tables first, then incremental updates)
+apply_sql_dir "/azerothcore/modules/mod-individual-progression/data/sql/world/base/" \
+  "$whost" "$wport" "$wuser" "$wpass" "$wdb"
+apply_sql_dir "/azerothcore/modules/mod-individual-progression/data/sql/world/updates/" \
+  "$whost" "$wport" "$wuser" "$wpass" "$wdb"
+apply_sql_dir "/azerothcore/modules/mod-individual-progression/data/sql/auth/updates/" \
+  "$ahost" "$aport" "$auser" "$apass" "$adb"
+apply_sql_dir "/azerothcore/modules/mod-individual-progression/data/sql/characters/updates/" \
+  "$chost" "$cport" "$cuser" "$cpass" "$cdb"
+
+echo "==> Module SQL import complete!"

--- a/apps/azerothcore-worldserver/Dockerfile
+++ b/apps/azerothcore-worldserver/Dockerfile
@@ -33,7 +33,3 @@ RUN for f in /azerothcore/env/dist/etc/modules/*.conf.dist; do cp "$f" "${f%.dis
 FROM acore/ac-wotlk-worldserver:master
 COPY --from=builder /azerothcore/env/dist/bin/worldserver /azerothcore/env/dist/bin/worldserver
 COPY --from=builder /azerothcore/env/dist/etc/modules/ /azerothcore/env/ref/etc/modules/
-COPY --from=builder /azerothcore-src/data/sql/updates/ /azerothcore-src/data/sql/updates/
-COPY --from=builder /azerothcore-src/modules/mod-solocraft/data/ /azerothcore-src/modules/mod-solocraft/data/
-COPY --from=builder /azerothcore-src/modules/mod-ah-bot/data/ /azerothcore-src/modules/mod-ah-bot/data/
-COPY --from=builder /azerothcore-src/modules/mod-individual-progression/data/ /azerothcore-src/modules/mod-individual-progression/data/


### PR DESCRIPTION
The pre-built dbimport binary cannot load custom modules (not compiled in), so module SQL was never applied. This adds a wrapper script that runs dbimport then applies module SQL directly via mysql --force for idempotency.

Worldserver SQL COPY statements removed since db-import now owns all SQL application; AC_UPDATES_ENABLE_DATABASES removed from values.yaml accordingly.