### PR TITLE
chore(renovate): group azerothcore wow image digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,12 @@
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["digest"],
       "commitMessagePrefix": "📣 "
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^acore/ac-wotlk-"],
+      "matchUpdateTypes": ["digest"],
+      "groupName": "azerothcore wow images"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a `packageRules` entry to group all `acore/ac-wotlk-*` digest updates into a single PR (`azerothcore wow images`)
- Previously each of the three images (authserver, worldserver, db-import) opened its own Renovate PR; now they will be batched together

## Test plan

- [x] Confirm next Renovate run opens a single PR for all three `acore/ac-wotlk-*:master` digest bumps instead of three separate ones