### PR TITLE
feat: add sandbox workspace images for Coder platform

### DIFF
--- a/apps/sandbox-base/Dockerfile
+++ b/apps/sandbox-base/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:24.04
+
+ARG VERSION
+ARG CHANNEL
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server \
+    curl \
+    wget \
+    git \
+    vim \
+    nano \
+    jq \
+    unzip \
+    ca-certificates \
+    sudo \
+    locales \
+    bash-completion \
+    ripgrep \
+    fd-find \
+    && locale-gen en_US.UTF-8 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash coder \
+    && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/coder \
+    && chmod 0440 /etc/sudoers.d/coder
+
+RUN mkdir -p /var/run/sshd \
+    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config \
+    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+    && ssh-keygen -A
+
+WORKDIR /home/coder

--- a/apps/sandbox-base/README.md
+++ b/apps/sandbox-base/README.md
@@ -1,0 +1,5 @@
+# sandbox-base
+
+Base image for Coder workspace sandboxes. Ubuntu 24.04 with OpenSSH server and a `coder` user (UID 1000) with passwordless sudo.
+
+Used as the base for all sandbox profile images (`sandbox-devops`, `sandbox-dotnet`, `sandbox-node`, `sandbox-python`).

--- a/apps/sandbox-base/ci/goss.yaml
+++ b/apps/sandbox-base/ci/goss.yaml
@@ -1,0 +1,16 @@
+---
+file:
+  /usr/sbin/sshd:
+    exists: true
+  /etc/ssh/sshd_config:
+    exists: true
+  /etc/sudoers.d/coder:
+    exists: true
+
+command:
+  git --version:
+    exit-status: 0
+  curl --version:
+    exit-status: 0
+  jq --version:
+    exit-status: 0

--- a/apps/sandbox-base/ci/latest.sh
+++ b/apps/sandbox-base/ci/latest.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "%s" "1.0.0"

--- a/apps/sandbox-base/metadata.json
+++ b/apps/sandbox-base/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "sandbox-base",
+  "base": true,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "Base Ubuntu 24.04 image with SSH server and coder user for Coder workspace sandboxes",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}

--- a/apps/sandbox-devops/Dockerfile
+++ b/apps/sandbox-devops/Dockerfile
@@ -1,0 +1,37 @@
+FROM ghcr.io/mmalyska/sandbox-base:rolling
+
+ARG VERSION
+ARG CHANNEL
+
+USER root
+
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=v1.32.0
+# renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VERSION=v3.17.0
+# renovate: datasource=github-releases depName=siderolabs/talos
+ARG TALOSCTL_VERSION=v1.9.0
+# renovate: datasource=github-releases depName=hashicorp/terraform
+ARG TERRAFORM_VERSION=1.10.0
+# renovate: datasource=github-releases depName=derailed/k9s
+ARG K9S_VERSION=v0.32.0
+
+RUN curl -fsSL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+      -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl \
+    && curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | \
+      DESIRED_VERSION=${HELM_VERSION} bash \
+    && curl -fsSL https://github.com/siderolabs/talos/releases/download/${TALOSCTL_VERSION}/talosctl-linux-amd64 \
+      -o /usr/local/bin/talosctl && chmod +x /usr/local/bin/talosctl
+
+RUN curl -fsSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+      -o /tmp/tf.zip && unzip /tmp/tf.zip -d /usr/local/bin && rm /tmp/tf.zip
+
+RUN curl -fsSL https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_amd64.tar.gz \
+      | tar xz -C /usr/local/bin k9s
+
+# renovate: datasource=github-releases depName=FiloSottile/age
+ARG AGE_VERSION=v1.2.0
+RUN curl -fsSL https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/age-${AGE_VERSION}-linux-amd64.tar.gz \
+      | tar xz -C /tmp && mv /tmp/age/age /usr/local/bin/ && mv /tmp/age/age-keygen /usr/local/bin/
+
+USER coder

--- a/apps/sandbox-devops/README.md
+++ b/apps/sandbox-devops/README.md
@@ -1,0 +1,3 @@
+# sandbox-devops
+
+Coder workspace sandbox for DevOps workflows. Extends `sandbox-base` with: kubectl, helm, talosctl, terraform, k9s, age.

--- a/apps/sandbox-devops/ci/goss.yaml
+++ b/apps/sandbox-devops/ci/goss.yaml
@@ -1,0 +1,22 @@
+---
+file:
+  /usr/local/bin/kubectl:
+    exists: true
+  /usr/local/bin/helm:
+    exists: true
+  /usr/local/bin/talosctl:
+    exists: true
+  /usr/local/bin/terraform:
+    exists: true
+  /usr/local/bin/k9s:
+    exists: true
+  /usr/local/bin/age:
+    exists: true
+
+command:
+  kubectl version --client:
+    exit-status: 0
+  helm version:
+    exit-status: 0
+  terraform version:
+    exit-status: 0

--- a/apps/sandbox-devops/ci/latest.sh
+++ b/apps/sandbox-devops/ci/latest.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "%s" "1.0.0"

--- a/apps/sandbox-devops/metadata.json
+++ b/apps/sandbox-devops/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "sandbox-devops",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "Coder workspace sandbox for DevOps workflows: kubectl, helm, talosctl, terraform, k9s, age",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}

--- a/apps/sandbox-dotnet/Dockerfile
+++ b/apps/sandbox-dotnet/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/mmalyska/sandbox-base:rolling
+
+ARG VERSION
+ARG CHANNEL
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dotnet-sdk-9.0 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER coder
+ENV PATH="$PATH:/home/coder/.dotnet/tools"
+RUN dotnet tool install -g dotnet-ef \
+    && dotnet tool install -g csharpier

--- a/apps/sandbox-dotnet/README.md
+++ b/apps/sandbox-dotnet/README.md
@@ -1,0 +1,3 @@
+# sandbox-dotnet
+
+Coder workspace sandbox for .NET development. Extends `sandbox-base` with: dotnet-sdk-9.0, dotnet-ef, csharpier.

--- a/apps/sandbox-dotnet/ci/goss.yaml
+++ b/apps/sandbox-dotnet/ci/goss.yaml
@@ -1,0 +1,4 @@
+---
+command:
+  dotnet --version:
+    exit-status: 0

--- a/apps/sandbox-dotnet/ci/latest.sh
+++ b/apps/sandbox-dotnet/ci/latest.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "%s" "1.0.0"

--- a/apps/sandbox-dotnet/metadata.json
+++ b/apps/sandbox-dotnet/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "sandbox-dotnet",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "Coder workspace sandbox for .NET development: dotnet-sdk-9.0, dotnet-ef, csharpier",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}

--- a/apps/sandbox-node/Dockerfile
+++ b/apps/sandbox-node/Dockerfile
@@ -1,0 +1,18 @@
+FROM ghcr.io/mmalyska/sandbox-base:rolling
+
+ARG VERSION
+ARG CHANNEL
+
+USER root
+
+# renovate: datasource=node-version depName=node
+ARG NODE_VERSION=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER coder
+ENV PNPM_HOME="/home/coder/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable pnpm \
+    && pnpm add -g expo-cli @expo/cli eas-cli

--- a/apps/sandbox-node/README.md
+++ b/apps/sandbox-node/README.md
@@ -1,0 +1,3 @@
+# sandbox-node
+
+Coder workspace sandbox for Node.js and mobile development. Extends `sandbox-base` with: Node.js 22, pnpm, expo-cli, eas-cli.

--- a/apps/sandbox-node/ci/goss.yaml
+++ b/apps/sandbox-node/ci/goss.yaml
@@ -1,0 +1,6 @@
+---
+command:
+  node --version:
+    exit-status: 0
+  npm --version:
+    exit-status: 0

--- a/apps/sandbox-node/ci/latest.sh
+++ b/apps/sandbox-node/ci/latest.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "%s" "1.0.0"

--- a/apps/sandbox-node/metadata.json
+++ b/apps/sandbox-node/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "sandbox-node",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "Coder workspace sandbox for Node.js/mobile development: Node.js 22, pnpm, expo-cli, eas-cli",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}

--- a/apps/sandbox-python/Dockerfile
+++ b/apps/sandbox-python/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/mmalyska/sandbox-base:rolling
+
+ARG VERSION
+ARG CHANNEL
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 \
+    python3.12-venv \
+    python3-pip \
+    python3.12-dev \
+    build-essential \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
+
+USER coder
+RUN uv pip install --system jupyter notebook pandas numpy scipy scikit-learn requests httpx

--- a/apps/sandbox-python/README.md
+++ b/apps/sandbox-python/README.md
@@ -1,0 +1,3 @@
+# sandbox-python
+
+Coder workspace sandbox for Python and data science. Extends `sandbox-base` with: Python 3.12, uv, jupyter, pandas, numpy, scipy, scikit-learn.

--- a/apps/sandbox-python/ci/goss.yaml
+++ b/apps/sandbox-python/ci/goss.yaml
@@ -1,0 +1,6 @@
+---
+command:
+  python3 --version:
+    exit-status: 0
+  uv --version:
+    exit-status: 0

--- a/apps/sandbox-python/ci/latest.sh
+++ b/apps/sandbox-python/ci/latest.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf "%s" "1.0.0"

--- a/apps/sandbox-python/metadata.json
+++ b/apps/sandbox-python/metadata.json
@@ -1,0 +1,18 @@
+{
+  "app": "sandbox-python",
+  "base": false,
+  "channels": [
+    {
+      "name": "stable",
+      "description": "Coder workspace sandbox for Python/data science: Python 3.12, uv, jupyter, pandas, numpy, scipy, scikit-learn",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "stable": true,
+      "tests": {
+        "enabled": true,
+        "type": "cli"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `sandbox-base`: Ubuntu 24.04 with OpenSSH server and `coder` user (UID 1000, passwordless sudo)
- Add `sandbox-devops`: kubectl, helm, talosctl, terraform, k9s, age
- Add `sandbox-dotnet`: dotnet-sdk-9.0, dotnet-ef, csharpier
- Add `sandbox-node`: Node.js 22, pnpm, expo-cli, eas-cli
- Add `sandbox-python`: Python 3.12, uv, jupyter, pandas/numpy/scipy/scikit-learn

All images are `linux/amd64` only (Talos K8s cluster). Used by the Coder OSS sandbox platform in home-ops.

## ⚠️ Build order dependency

Child images (`sandbox-devops`, `sandbox-dotnet`, `sandbox-node`, `sandbox-python`) build `FROM ghcr.io/mmalyska/sandbox-base:rolling`.

After this PR merges:
1. `image-rebuild.yaml` will build all 5 images in parallel — `sandbox-base` will succeed but child images may fail (base not yet pushed)
2. Use **Actions → release-manual → Run workflow** to rebuild the 4 child images after `sandbox-base:rolling` is available on GHCR

## Test plan

- [ ] `sandbox-base` Goss tests pass (sshd, coder sudoers, git/curl/jq present)
- [ ] `sandbox-devops` Goss tests pass (kubectl/helm/terraform version commands)
- [ ] `sandbox-dotnet` Goss tests pass (`dotnet --version`)
- [ ] `sandbox-node` Goss tests pass (`node --version`, `npm --version`)
- [ ] `sandbox-python` Goss tests pass (`python3 --version`, `uv --version`)